### PR TITLE
move to `ddev` domain

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ defaults:
     shell: bash
 
 env:
-  NIGHTLY_DDEV_PR_URL: "https://nightly.link/drud/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
+  NIGHTLY_DDEV_PR_URL: "https://nightly.link/ddev/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
   # Allow ddev get to use a github token to prevent rate limiting by tests
   DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -53,15 +53,15 @@ jobs:
 
     - name: Use ddev stable
       if: matrix.ddev_version == 'stable'
-      run: brew install drud/ddev/ddev
+      run: brew install ddev/ddev/ddev
 
     - name: Use ddev edge
       if: matrix.ddev_version == 'edge'
-      run: brew install drud/ddev-edge/ddev
+      run: brew install ddev/ddev-edge/ddev
 
     - name: Use ddev HEAD
       if: matrix.ddev_version == 'HEAD'
-      run: brew install --HEAD drud/ddev/ddev
+      run: brew install --HEAD ddev/ddev/ddev
 
     - name: Use ddev PR
       if: matrix.ddev_version == 'PR'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ddev-browsersync <!-- omit in toc -->
 
-[![tests](https://github.com/drud/ddev-browsersync/actions/workflows/tests.yml/badge.svg)](https://github.com/drud/ddev-browsersync/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
+[![tests](https://github.com/ddev/ddev-browsersync/actions/workflows/tests.yml/badge.svg)](https://github.com/ddev/ddev-browsersync/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
 
 - [Introduction](#introduction)
 - [Getting Started](#getting-started)
@@ -25,7 +25,7 @@ This add-on allows you to run [Browsersync](https://browsersync.io/) through the
 - Install the DDEV browsersync add-on:
 
 ```shell
-ddev get drud/ddev-browsersync
+ddev get ddev/ddev-browsersync
 ddev restart
 ddev browsersync
 ```

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -39,8 +39,8 @@ teardown() {
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev get drud/ddev-browsersync with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get drud/ddev-browsersync
+  echo "# ddev get ddev/ddev-browsersync with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev get ddev/ddev-browsersync
   ddev restart
   ./run-ddev-browsersync &
   sleep 5


### PR DESCRIPTION
This PR replaces all `drud` references with `DDEV`.

- Badge reference is active
- brew references should be active, and should be caught by tests