### PR TITLE
command runs "per-project"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,8 @@ env:
   NIGHTLY_DDEV_PR_URL: "https://nightly.link/ddev/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
   # Allow ddev get to use a github token to prevent rate limiting by tests
   DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # Allow `--HEAD` flag when running tests against HEAD
+  HOMEBREW_NO_INSTALL_FROM_API: 1
 
 jobs:
   tests:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 - [Introduction](#introduction)
 - [Getting Started](#getting-started)
-  - [Note](#note)
 - [What does this add-on do and add?](#what-does-this-add-on-do-and-add)
 - [Other ways to use browsersync with this add-on](#other-ways-to-use-browsersync-with-this-add-on)
   - [Basic usage](#basic-usage)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 - [Introduction](#introduction)
 - [Getting Started](#getting-started)
+  - [Note](#note)
 - [What does this add-on do and add?](#what-does-this-add-on-do-and-add)
 - [Other ways to use browsersync with this add-on](#other-ways-to-use-browsersync-with-this-add-on)
   - [Basic usage](#basic-usage)
@@ -38,13 +39,26 @@ NOTE: The browsersync'd URL is ***HTTPS***, not HTTP. ddev-router redirects traf
 EG.
 "External: <http://d9.ddev.site:3000>" => Access on **<https://d9.ddev.site:3000>**
 
+### Note
+
+From version `2.5.0`, this addon uses a "per-project" approach. This will not affect usage as project-level command have higher priority than global commands.
+
+When installing current versions, a warning is displayed if the global command (`~/.ddev/commands/web/browsersync`) is detected. You may safely delete his file.
+
+If you run `ddev browsersync` from multiple local projects and receive a `Error: unknown command "browsersync" for "ddev"`, run the following command to add the command to the project as needed.
+
+  ```shell
+  ddev get ddev/ddev-browsersync
+  ```
+
+
 ## What does this add-on do and add?
 
 1. Checks to make sure the DDEV version is adequate.
 2. Adds `.ddev/web-build/Dockerfile.ddev-browsersync`, which installs browsersync using npm.
 3. Adds a `browser-sync.js` to define the operation of the base setup.
 4. Adds a `.ddev/docker-compose.browsersync.yaml`, which exposes and routes the ports necessary.
-5. Adds a `ddev browsersync` shell command globally, which lets you easily start browsersync when you want it.
+5. Adds a `ddev browsersync` shell command, which lets you easily start browsersync when you want it.
 
 ## Other ways to use browsersync with this add-on
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ EG.
 
 When installing current versions, a warning is displayed if the global command (`~/.ddev/commands/web/browsersync`) is detected. You may safely delete his file.
 
-If you run `ddev browsersync` from multiple local projects and receive a `Error: unknown command "browsersync" for "ddev"`, run the following command to add the command to the project as needed.
+If you run `ddev browsersync` from a local project and get `Error: unknown command "browsersync" for "ddev"`, run the following to add the command to the project:
 
   ```shell
   ddev get ddev/ddev-browsersync

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ NOTE: The browsersync'd URL is ***HTTPS***, not HTTP. ddev-router redirects traf
 EG.
 "External: <http://d9.ddev.site:3000>" => Access on **<https://d9.ddev.site:3000>**
 
-### Note
 
 From version `2.5.0`, this addon uses a "per-project" approach. This will not affect usage as project-level command have higher priority than global commands.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ EG.
 "External: <http://d9.ddev.site:3000>" => Access on **<https://d9.ddev.site:3000>**
 
 
-From version `2.5.0`, this addon uses a "per-project" approach. This will not affect usage as project-level command have higher priority than global commands.
+> :bulb: This add-on moves to a per-project approach in v2.5.0+. You can safely delete the global `~/.ddev/commands/web/browsersync` once you’re on v2.5.0 or higher—this will not affect usage.
 
 When installing current versions, a warning is displayed if the global command (`~/.ddev/commands/web/browsersync`) is detected. You may safely delete his file.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ EG.
 
 > :bulb: This add-on moves to a per-project approach in v2.5.0+. You can safely delete the global `~/.ddev/commands/web/browsersync` once you’re on v2.5.0 or higher—this will not affect usage.
 
-When installing current versions, a warning is displayed if the global command (`~/.ddev/commands/web/browsersync`) is detected. You may safely delete his file.
 
 If you run `ddev browsersync` from a local project and get `Error: unknown command "browsersync" for "ddev"`, run the following to add the command to the project:
 

--- a/install.yaml
+++ b/install.yaml
@@ -1,7 +1,7 @@
 name: ddev-browsersync
 
 pre_install_actions:
-- | 
+- |
   #ddev-nodisplay
   #ddev-description:Check for minimum DDEV requirement (v1.19.3)
   if ! ( ddev debug capabilities 2>/dev/null | grep multiple-dockerfiles >/dev/null 2>&1 ) ; then
@@ -12,11 +12,7 @@ project_files:
   - docker-compose.browsersync.yaml
   - web-build/Dockerfile.ddev-browsersync
   - browser-sync.js
-
-
-global_files:
   - commands/web/browsersync
 
 
 post_install_actions:
-

--- a/install.yaml
+++ b/install.yaml
@@ -16,3 +16,9 @@ project_files:
 
 
 post_install_actions:
+- |
+  #ddev-nodisplay
+  #ddev-description:Check for global 'browser-sync.js'
+  if ( test -f "$HOME/.ddev/commands/web/browsersync" ) ; then
+    echo "Note: '~/.ddev/commands/web/browsersync' is no longer required and can be safely removed." && exit 0
+  fi


### PR DESCRIPTION
This PR moves the `browsersync` command to a "per-project" level.

The command should not be available if the project doesn't support ddev-browsersync.
