### PR TITLE
remove un-needed ENV

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,8 +22,6 @@ env:
   NIGHTLY_DDEV_PR_URL: "https://nightly.link/ddev/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
   # Allow ddev get to use a github token to prevent rate limiting by tests
   DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  # Allow `--HEAD` flag when running tests against HEAD
-  HOMEBREW_NO_INSTALL_FROM_API: 1
 
 jobs:
   tests:


### PR DESCRIPTION
Unfortunately, HOMEBREW_NO_INSTALL_FROM_API is still set by Github and we don't have control of it