### PR TITLE
Convert to use official github action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Environment setup
+      run: |
+        sudo apt-get update >/dev/null && sudo apt-get install -y expect >/dev/null
+
     - uses: ddev/github-action-add-on-test@v1
       with:
         ddev_version: ${{ matrix.ddev_version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,78 +13,24 @@ on:
         description: 'Debug with tmate set "debug_enabled"'
         required: false
         default: "false"
-
-defaults:
-  run:
-    shell: bash
-
 env:
-  NIGHTLY_DDEV_PR_URL: "https://nightly.link/ddev/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
   # Allow ddev get to use a github token to prevent rate limiting by tests
   DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   tests:
-    defaults:
-      run:
-        shell: bash
-
     strategy:
       matrix:
         ddev_version: [stable, HEAD]
-#        ddev_version: [stable, edge, HEAD, PR]
       fail-fast: false
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Homebrew
-      id: set-up-homebrew
-      uses: Homebrew/actions/setup-homebrew@master
-
-    - name: Environment setup
-      run: |
-        brew install bats-core mkcert
-        sudo apt-get update >/dev/null && sudo apt-get install -y expect >/dev/null
-        # Without this .curlrc some linux images don't respect mkcert certs
-        echo "capath=/etc/ssl/certs/" >>~/.curlrc
-        mkcert -install
-
-    - name: Use ddev stable
-      if: matrix.ddev_version == 'stable'
-      run: brew install ddev/ddev/ddev
-
-    - name: Use ddev edge
-      if: matrix.ddev_version == 'edge'
-      run: brew install ddev/ddev-edge/ddev
-
-    - name: Use ddev HEAD
-      if: matrix.ddev_version == 'HEAD'
-      run: brew install --HEAD ddev/ddev/ddev
-
-    - name: Use ddev PR
-      if: matrix.ddev_version == 'PR'
-      run: |
-        curl -sSL -o ddev_linux.zip ${NIGHTLY_DDEV_PR_URL}
-        unzip ddev_linux.zip
-        mv ddev /usr/local/bin/ddev && chmod +x /usr/local/bin/ddev
-
-    - name: Download docker images
-      run: |
-        mkdir junk && pushd junk && ddev config --auto && ddev debug download-images >/dev/null
-        docker pull memcached:1.6 >/dev/null
-    - name: tmate debugging session
-      uses: mxschmitt/action-tmate@v3
+    - uses: ddev/github-action-add-on-test@v1
       with:
-        limit-access-to-actor: true
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
-
-    - name: tests
-      run: bats tests
-
-    # keepalive-workflow adds a dummy commit if there's no other action here, keeps
-    # GitHub from turning off tests after 60 days
-    - uses: gautamkrishnar/keepalive-workflow@v1
-      if: matrix.ddev_version == 'stable'
+        ddev_version: ${{ matrix.ddev_version }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        debug_enabled: ${{ github.event.inputs.debug_enabled }}
+        addon_repository: ${{ env.GITHUB_REPOSITORY }}
+        addon_ref: ${{ env.GITHUB_REF }}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,18 +1,24 @@
 setup() {
   set -eu -o pipefail
+
   # Fail early if old ddev is installed
   ddev debug capabilities | grep multiple-dockerfiles >/dev/null || exit 3
+
   export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
-  export TESTDIR=~/tmp/testbrowsersync
+  export TESTDIR=~/tmp/test-browsersync
   mkdir -p "${TESTDIR}"
-  export PROJNAME=ddev-browsersync
+  export PROJNAME=test-browsersync
   export DDEV_NON_INTERACTIVE=true
   ddev delete -Oy ${PROJNAME} >/dev/null || true
   cp tests/run-ddev-browsersync "${TESTDIR}"
   cd "${TESTDIR}"
-  ddev config --project-name=${PROJNAME} >/dev/null
+  ddev config --project-name=${PROJNAME}
+
+  # Add simple page to test against.
   echo "<html><head></head><body>this is a test</body>" >index.html
+
   ddev start -y
+
   CURLCMD="curl -s --fail"
   # I can't currently get curl to trust mkcert CA on macOS
   if [[ "$OSTYPE" == "darwin"* ]]; then CURLCMD="curl -s -k --fail"; fi
@@ -21,7 +27,7 @@ setup() {
 teardown() {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  ddev delete -Oy ${PROJNAME} >/dev/null
+  ddev delete -Oy ${PROJNAME}
   [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
 }
 
@@ -33,8 +39,8 @@ healthcheck() {
   set -eu -o pipefail
   cd ${TESTDIR}
   echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DIR} >/dev/null
-  ddev restart >/dev/null
+  ddev get ${DIR}
+  ddev restart
   ./run-ddev-browsersync &
   sleep 5
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -25,6 +25,10 @@ teardown() {
   [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
 }
 
+healthcheck() {
+  ${CURLCMD} https://${PROJNAME}.ddev.site:3000 | grep "this is a test"
+}
+
 @test "install from directory" {
   set -eu -o pipefail
   cd ${TESTDIR}
@@ -33,7 +37,9 @@ teardown() {
   ddev restart >/dev/null
   ./run-ddev-browsersync &
   sleep 5
-  ${CURLCMD} https://${PROJNAME}.ddev.site:3000 | grep "this is a test"
+
+  # Check service works
+  healthcheck
 }
 
 @test "install from release" {
@@ -44,6 +50,7 @@ teardown() {
   ddev restart
   ./run-ddev-browsersync &
   sleep 5
-  # After https PR goes in, this should be changed to just https
-  (${CURLCMD} https://${PROJNAME}.ddev.site:3000 || ${CURLCMD} http://${PROJNAME}.ddev.site:3000) | grep "this is a test"
+
+  # Check service works
+  healthcheck
 }


### PR DESCRIPTION
The new image helps centralize many common steps and makes for easier maintainence:

https://github.com/ddev/github-action-add-on-test