### PR TITLE
⏫ bump github-action-add-on

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,11 @@ env:
   # Allow ddev get to use a github token to prevent rate limiting by tests
   DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+
+# Required permissions for keep-alive, used by ddev/github-action-add-on-test
+permissions:
+  actions: write
+
 jobs:
   tests:
     strategy:
@@ -31,7 +36,7 @@ jobs:
       run: |
         sudo apt-get update >/dev/null && sudo apt-get install -y expect >/dev/null
 
-    - uses: ddev/github-action-add-on-test@v1
+    - uses: ddev/github-action-add-on-test@v2
       with:
         ddev_version: ${{ matrix.ddev_version }}
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## The Issue

ddev-browsersync repo recently receieved some dummy commits to keep the tests alive. This repo should be using github-action-add-on-test` >= `2` to prevent this.

## How This PR Solves The Issue

This PR bumps 'github-action-add-on-test' to the latest and greatest.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

