### PR TITLE
WordPress bugfix - Sometimes the CMS thought the siteurl was localhost

### DIFF
--- a/scripts/wp-config-ddev-browsersync.php
+++ b/scripts/wp-config-ddev-browsersync.php
@@ -3,7 +3,7 @@
 /** Allow any domain/port so WordPress allows browsersync's :3000 URLs */
 if ( ! empty( $_SERVER['SERVER_PORT'] ) && ! empty( $_SERVER['SERVER_NAME'] ) ) {
 	// phpcs:ignore
-	$domain = sprintf( '%s://%s', $_SERVER['SERVER_PORT'] == 80 ? 'http' : 'https', $_SERVER['DDEV_HOSTNAME'] );
+	$domain = sprintf( '%s://%s', $_SERVER['SERVER_PORT'] == 80 ? 'http' : 'https', $_SERVER['HTTP_X_FORWARDED_HOST'] );
 
 	/** WP_HOME URL */
 	define( 'WP_HOME', $domain );

--- a/scripts/wp-config-ddev-browsersync.php
+++ b/scripts/wp-config-ddev-browsersync.php
@@ -3,7 +3,7 @@
 /** Allow any domain/port so WordPress allows browsersync's :3000 URLs */
 if ( ! empty( $_SERVER['SERVER_PORT'] ) && ! empty( $_SERVER['SERVER_NAME'] ) ) {
 	// phpcs:ignore
-	$domain = sprintf( '%s://%s', $_SERVER['SERVER_PORT'] == 80 ? 'http' : 'https', $_SERVER['SERVER_NAME'] );
+	$domain = sprintf( '%s://%s', $_SERVER['SERVER_PORT'] == 80 ? 'http' : 'https', $_SERVER['DDEV_HOSTNAME'] );
 
 	/** WP_HOME URL */
 	define( 'WP_HOME', $domain );


### PR DESCRIPTION
## The Issue

Some assets would not load properly because the URL WordPress is working with was "localhost", when it should be the ddev project URL. The localhost URLs don't resolve and cause 404s. 

![image](https://github.com/user-attachments/assets/f6332688-829c-4822-892c-95083bf905a2)

## How This PR Solves The Issue

Instead of using `$_SERVER['SERVER_NAME']` I've updated the WordPress Browsersync config file to use `$_SERVER['DDEV_HOSTNAME']`.

After: 
![image](https://github.com/user-attachments/assets/b0e23e0a-a449-4852-bd62-2d5f2d231400)

## Manual Testing Instructions

A - Load up a page with images and they should no longer 404 (if you had the issue). 

B - Test the value of $domain before and after. 

## Release/Deployment Notes

I don't think this affects anything else. 

