### PR TITLE
fix: update install command in tests

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -38,8 +38,8 @@ healthcheck() {
 @test "install from directory" {
   set -eu -o pipefail
   cd ${TESTDIR}
-  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DIR}
+  echo "# ddev addon get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev addon get ${DIR}
   ddev restart
   ./run-ddev-browsersync &
   sleep 5
@@ -51,8 +51,8 @@ healthcheck() {
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev get ddev/ddev-browsersync with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ddev/ddev-browsersync
+  echo "# ddev addon get ddev/ddev-browsersync with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev addon get ddev/ddev-browsersync
   ddev restart
   ./run-ddev-browsersync &
   sleep 5


### PR DESCRIPTION
## The Issue

Currently, the tests use the deprecated `ddev get` command.

## How This PR Solves The Issue

This PR updates the tests to use `ddev addon get`

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

