### PR TITLE
fix: show correct port on running `ddev browsersync`

### DIFF
--- a/commands/web/browsersync
+++ b/commands/web/browsersync
@@ -6,5 +6,5 @@
 ## Example: "ddev browsersync"
 ## ExecRaw: true
 
-echo "Proxying browsersync on ${DDEV_PRIMARY_URL}:3000"
+echo "Proxying Browsersync on $(echo ${DDEV_PRIMARY_URL} | sed -E 's/:[0-9]+//'):3000"
 browser-sync start -c /var/www/html/.ddev/browser-sync.cjs  | grep -v "Access URLs\|--------------------\|Local: http\|External: http"


### PR DESCRIPTION
## The Issue

I noticed when you don't use the default router ports 80/443, the link is wrong.

## How This PR Solves The Issue

Fixes it.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

