### PR TITLE
Fix issue where wordpress config isn't read/written in correct directory, fixes #76

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -39,5 +39,10 @@ removal_actions:
   - |
     #ddev-nodisplay
     #ddev-description:Remove browsersync settings for WordPress if applicable
-    rm -f "${DDEV_APPROOT}/wp-config-ddev-browsersync.php"
+    if [ $DDEV_DOCROOT != "" ]; then
+      DDEV_SITE_PATH="${DDEV_APPROOT}/${DDEV_DOCROOT}" ;
+    else
+      DDEV_SITE_PATH=$DDEV_APPROOT
+    fi
+    rm -f "${DDEV_SITE_PATH}/wp-config-ddev-browsersync.php"
     scripts/remove-wordpress-settings.sh

--- a/scripts/remove-wordpress-settings.sh
+++ b/scripts/remove-wordpress-settings.sh
@@ -11,7 +11,13 @@ if ( ddev debug configyaml 2>/dev/null | grep 'disable_settings_management:\s*tr
   exit 0
 fi
 
-SETTINGS_FILE_NAME="${DDEV_APPROOT}/wp-config.php"
+if [ $DDEV_DOCROOT != "" ]; then
+  DDEV_SITE_PATH="${DDEV_APPROOT}/${DDEV_DOCROOT}" ;
+else
+  DDEV_SITE_PATH=$DDEV_APPROOT
+fi
+
+SETTINGS_FILE_NAME="${DDEV_SITE_PATH}/wp-config.php"
 
 echo "Removing wp-config-ddev-browsersync.php from: ${SETTINGS_FILE_NAME}"
 
@@ -20,5 +26,5 @@ awk '
 /\/\*\* Include for ddev-browsersync to modify WP_HOME and WP_SITEURL\./ { skip=1 }
 skip && /\}.*$/ { skip=0; getline; next }
 !skip
-' ${DDEV_APPROOT}/wp-config.php > ${DDEV_APPROOT}/wp-config-temp.php
-mv ${DDEV_APPROOT}/wp-config-temp.php ${DDEV_APPROOT}/wp-config.php
+' ${DDEV_SITE_PATH}/wp-config.php > ${DDEV_SITE_PATH}/wp-config-temp.php
+mv ${DDEV_SITE_PATH}/wp-config-temp.php ${DDEV_SITE_PATH}/wp-config.php

--- a/scripts/setup-wordpress-settings.sh
+++ b/scripts/setup-wordpress-settings.sh
@@ -11,14 +11,20 @@ if ( ddev debug configyaml 2>/dev/null | grep 'disable_settings_management:\s*tr
   exit 0
 fi
 
-cp scripts/wp-config-ddev-browsersync.php $DDEV_APPROOT/
+if [ $DDEV_DOCROOT != "" ]; then
+  DDEV_SITE_PATH="${DDEV_APPROOT}/${DDEV_DOCROOT}" ;
+else
+  DDEV_SITE_PATH=$DDEV_APPROOT
+fi
 
-SETTINGS_FILE_NAME="${DDEV_APPROOT}/wp-config.php"
+cp scripts/wp-config-ddev-browsersync.php $DDEV_SITE_PATH/
+
+SETTINGS_FILE_NAME="${DDEV_SITE_PATH}/wp-config.php"
 
 echo "Settings file name: ${SETTINGS_FILE_NAME}"
 
 # If wp-config.php already contains the require_once() then exit early.
-if grep -q "/\*\* Include for ddev-browsersync to modify WP_HOME and WP_SITEURL. \*/" ${DDEV_APPROOT}/wp-config.php; then
+if grep -q "/\*\* Include for ddev-browsersync to modify WP_HOME and WP_SITEURL. \*/" ${DDEV_SITE_PATH}/wp-config.php; then
    exit 0
 fi
 
@@ -38,7 +44,7 @@ awk '
     next
 }
 {print}
-' ${DDEV_APPROOT}/wp-config.php > ${DDEV_APPROOT}/wp-config-temp.php
+' ${DDEV_SITE_PATH}/wp-config.php > ${DDEV_SITE_PATH}/wp-config-temp.php
 
 # Replace the real config file with the modified version in temporary file.
-mv ${DDEV_APPROOT}/wp-config-temp.php ${DDEV_APPROOT}/wp-config.php
+mv ${DDEV_SITE_PATH}/wp-config-temp.php ${DDEV_SITE_PATH}/wp-config.php


### PR DESCRIPTION
when docroot isn't empty

Close #76

## The Issue

- #76 

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Make the install/uninstall scripts aware of the ddev docroot if one is set

## Manual Testing Instructions

1. create a new ddev WordPress project, with a subdirectory docroot
2.  `ddev config --project-type=wordpress --docroot=html`
3. `ddev wp core download --path=html`
4. `ddev launch` and follow prompts 

(At this point, if you install the browsersync addon from it's main source, you'll see that the config files are incorrectly written to the top-level directory rather than to the docroot. You can't successfully remove the addon from this state either because it fails on removing things. You should restart these testing instructions on a fresh install)

5. install the addon `ddev add-on get https://github.com/jakeparis/ddev-browsersync/tarball/main`
6. `ddev restart`
7. The `wp-config-ddev-browsersync.php` file should be written into the docroot, next to `wp-config.php`
8. Extra config lines should be written into the `wp-config.php` file
   ```php
         /** Include for ddev-browsersync to modify WP_HOME and WP_SITEURL. */
      $ddev_browsersync_settings = dirname( __FILE__ ) . "/wp-config-ddev-browsersync.php";
      if ( is_readable( $ddev_browsersync_settings ) ) {
          require_once( $ddev_browsersync_settings );
      }
   ```

## Automated Testing Overview

Didn't change tests

## Release/Deployment Notes

No