### PR TITLE
Bugfix for failure to include custom config in wp config, fixes #78

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ ddev exec npm run watch
 
 ### WordPress Configuration Changes
 
+When this add-on is added to a WordPress project, DDEV's management of the installation files is turned
+off. 
+
 The changes this add-on makes to the `wp-config-ddev.php` file during installation can be seen below.
 
 The `wp-config-ddev-browserync.php` file is included before the `/** WP_HOME URL */` comment.

--- a/install.yaml
+++ b/install.yaml
@@ -34,6 +34,13 @@ post_install_actions:
     #ddev-nodisplay
     #ddev-description:Install browsersync settings for WordPress if applicable
     scripts/setup-wordpress-settings.sh
+  - |
+    #ddev-nodisplay
+    #ddev-description:Check for WordPress and disable ddev management of wp-config file
+    if [[ $DDEV_PROJECT_TYPE = 'wordpress' ]]; then 
+      ddev config --disable-settings-management=true;
+    fi
+
 
 removal_actions:
   - |
@@ -41,3 +48,9 @@ removal_actions:
     #ddev-description:Remove browsersync settings for WordPress if applicable
     rm -f "${DDEV_APPROOT}/wp-config-ddev-browsersync.php"
     scripts/remove-wordpress-settings.sh
+  # Don't automatically renable settings management in case user didn't have it enabled in the first place
+  - |
+    if [[ $DDEV_PROJECT_TYPE = 'wordpress' ]]; then 
+      echo "Note: You may wish to renable ddev's management of the wp-config file:"
+      echo "     Run 'ddev config --disable-settings-management=false && ddev restart'"
+    fi

--- a/scripts/remove-wordpress-settings.sh
+++ b/scripts/remove-wordpress-settings.sh
@@ -7,9 +7,9 @@ then
   exit 0
 fi
 
-if ( ddev debug configyaml 2>/dev/null | grep 'disable_settings_management:\s*true' >/dev/null 2>&1 ) ; then
-  exit 0
-fi
+# if ( ddev debug configyaml 2>/dev/null | grep 'disable_settings_management:\s*true' >/dev/null 2>&1 ) ; then
+#   exit 0
+# fi
 
 SETTINGS_FILE_NAME="${DDEV_APPROOT}/wp-config.php"
 

--- a/scripts/setup-wordpress-settings.sh
+++ b/scripts/setup-wordpress-settings.sh
@@ -23,18 +23,17 @@ if grep -q "/\*\* Include for ddev-browsersync to modify WP_HOME and WP_SITEURL.
 fi
 
 echo "Adding wp-config-ddev-browsersync.php to: ${SETTINGS_FILE_NAME}"
-
+ 
 # Append our code before the ddev config comment.
 awk '
-/\/\/ Include for ddev-managed settings in wp-config-ddev.php./ {
+/\/\/ Include for settings managed by ddev./ {
     print "/** Include for ddev-browsersync to modify WP_HOME and WP_SITEURL. */"
     print "$ddev_browsersync_settings = dirname( __FILE__ ) . \"/wp-config-ddev-browsersync.php\";"
-    print ""
     print "if ( is_readable( $ddev_browsersync_settings ) ) {"
     print "    require_once( $ddev_browsersync_settings );"
     print "}"
     print ""
-    print "// Include for ddev-managed settings in wp-config-ddev.php."
+    print "// Include for settings managed by ddev."
     next
 }
 {print}

--- a/scripts/setup-wordpress-settings.sh
+++ b/scripts/setup-wordpress-settings.sh
@@ -7,9 +7,9 @@ then
   exit 0
 fi
 
-if ( ddev debug configyaml 2>/dev/null | grep 'disable_settings_management:\s*true' >/dev/null 2>&1 ) ; then
-  exit 0
-fi
+# if ( ddev debug configyaml 2>/dev/null | grep 'disable_settings_management:\s*true' >/dev/null 2>&1 ) ; then
+#   exit 0
+# fi
 
 cp scripts/wp-config-ddev-browsersync.php $DDEV_APPROOT/
 


### PR DESCRIPTION
## The Issue

- #78 

This fixes the issue where the include for the custom config isn't written into the main wordpress config file

## How This PR Solves The Issue

Scan for the correct comment string

## Manual Testing Instructions

1. create a new ddev WordPress project
    2.  `ddev config --project-type=wordpress`
    3. `ddev wp core download`
    4. `ddev launch` and follow prompts 
2. install this addon: `ddev add-on get https://github.com/jakeparis/ddev-browsersync/tarball/bugfix/failed-config-install`
3. `ddev restart`
4. The `wp-config.php` file should be updated with the following text:
   ```php
	/** Include for ddev-browsersync to modify WP_HOME and WP_SITEURL. */
	$ddev_browsersync_settings = dirname( __FILE__ ) . "/wp-config-ddev-browsersync.php";
	if ( is_readable( $ddev_browsersync_settings ) ) {
	    require_once( $ddev_browsersync_settings );
	}
	```

## Automated Testing Overview

None changed

## Release/Deployment Notes

No
