### PR TITLE
Fix error when WordPress is multisite, fixes #80

### DIFF
--- a/browser-sync.cjs
+++ b/browser-sync.cjs
@@ -2,6 +2,7 @@
 let docroot = process.env.DDEV_DOCROOT;
 let filesdir = process.env.DDEV_FILES_DIR;
 let url = process.env.DDEV_HOSTNAME;
+let nonSslUrl = process.env.DDEV_PRIMARY_URL.replace( /^https:/, 'http:' )
 
 if (filesdir === "") {
     filesdir = null
@@ -15,7 +16,7 @@ module.exports = {
     ui: false,
     server: false,
     proxy: {
-        target: "localhost"
+        target: nonSslUrl
     },
     host: url,
 }


### PR DESCRIPTION
by using the correct ddev url in the proxy config

## The Issue

- #80

When WordPress is in multisite configuration, when trying to add `:3000` to subsite's urls, you are incorrectly redirected back to the network home page.

## How This PR Solves The Issue

Fix this by using the actual DDEV_PRIMARY_URL in the proxy config for browsersync, rather than hardcoding "localhost"

## Manual Testing Instructions
1. create a new ddev wordpress project in a directory called `test`
  `mkdir test && cd test`
1. create ddev project
  `ddev config --project-type=wordpress --webserver-type=apache-fpm`
1.  install this patched addon
  `ddev add-on get https://github.com/jakeparis/ddev-browsersync/tarball/fix-hostname-error`
1. setup wordpress
  `ddev wp core download`
1. install multisite (I'm using default ddev domain of ddev.site here): 
  `ddev wp core multisite-install --url=test.ddev.site --title=foo --admin_email=me@example.com --admin_password=admin --admin_user=admin`
1. create an **.htaccess** file
  `vim .htaccess`
1. add the standard wordpress multisite rewrites into the .htaccess file:
```
RewriteEngine On
RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
RewriteBase /
RewriteRule ^index\.php$ - [L]

# add a trailing slash to /wp-admin
RewriteRule ^([_0-9a-zA-Z-]+/)?wp-admin$ $1wp-admin/ [R=301,L]

RewriteCond %{REQUEST_FILENAME} -f [OR]
RewriteCond %{REQUEST_FILENAME} -d
RewriteRule ^ - [L]
RewriteRule ^([_0-9a-zA-Z-]+/)?(wp-(content|admin|includes).*) $2 [L]
RewriteRule ^([_0-9a-zA-Z-]+/)?(.*\.php)$ $2 [L]
RewriteRule . index.php [L]
```
8. create a second site
  `ddev wp site create --slug=site2`
9. turn on browsersync
  `ddev browsersync`
10. visit the sub site on port 3000:  `https://test.ddev.site:3000/site2` in your browser
11. The current page will reload as expected, and you briefly see the "browersync connected" notification in the upper right. the url should stay on `https://test.ddev.site:3000/site2`

If you did this last step 10 on the main version of the addon, you would incorreclty be redirected to test.ddev.site with the port removed because of #80 
 
## Automated Testing Overview

Didn't add any tests.

## Release/Deployment Notes

No.
