### PR TITLE
Updating the scripts to resolve `[: !=: unary operator expected` errors

### DIFF
--- a/scripts/remove-wordpress-settings.sh
+++ b/scripts/remove-wordpress-settings.sh
@@ -2,7 +2,7 @@
 #ddev-generated
 set -e
 
-if [[ $DDEV_PROJECT_TYPE != wordpress ]] ;
+if [[ "$DDEV_PROJECT_TYPE" != "wordpress" ]] ;
 then
   exit 0
 fi
@@ -11,7 +11,7 @@ fi
 #   exit 0
 # fi
 
-if [ $DDEV_DOCROOT != "" ]; then
+if [ "$DDEV_DOCROOT" != "" ]; then
   DDEV_SITE_PATH="${DDEV_APPROOT}/${DDEV_DOCROOT}" ;
 else
   DDEV_SITE_PATH=$DDEV_APPROOT

--- a/scripts/setup-wordpress-settings.sh
+++ b/scripts/setup-wordpress-settings.sh
@@ -2,7 +2,7 @@
 #ddev-generated
 set -e
 
-if [[ $DDEV_PROJECT_TYPE != wordpress ]] ;
+if [[ "$DDEV_PROJECT_TYPE" != "wordpress" ]] ;
 then
   exit 0
 fi
@@ -11,7 +11,7 @@ fi
 #   exit 0
 # fi
 
-if [ $DDEV_DOCROOT != "" ]; then
+if [ "$DDEV_DOCROOT" != "" ]; then
   DDEV_SITE_PATH="${DDEV_APPROOT}/${DDEV_DOCROOT}" ;
 else
   DDEV_SITE_PATH=$DDEV_APPROOT
@@ -35,7 +35,7 @@ awk '
 /\/\/ Include for settings managed by ddev./ {
     print "/** Include for ddev-browsersync to modify WP_HOME and WP_SITEURL. */"
     print "$ddev_browsersync_settings = dirname( __FILE__ ) . \"/wp-config-ddev-browsersync.php\";"
-    print "if ( is_readable( $ddev_browsersync_settings ) ) {"
+    print "if (  getenv( \"IS_DDEV_PROJECT\" ) == \"true\" && is_readable( $ddev_browsersync_settings ) ) {"
     print "    require_once( $ddev_browsersync_settings );"
     print "}"
     print ""


### PR DESCRIPTION
## The Issue

When adding or removing with `ddev add-on get ddev/ddev-browsersync` you see errors such as: 
`[: !=: unary operator expected`

Full output: 
```
ddev add-on get ddev/ddev-browsersync
Installing ddev/ddev-browsersync:2.14 
2.14_1572110135.tar.gz 11.71 KiB / ? [-------------------------------------------------------------------------------------------------=------------------------------------------------------------] 119.86% 0s 

Installing project-level components: 
👍 config.browsersync.yaml 
👍 web-build/Dockerfile.ddev-browsersync 
👍 browser-sync.cjs 
👍 commands/web/browsersync 
👍 scripts/wp-config-ddev-browsersync.php 
👍 scripts/remove-wordpress-settings.sh 
👍 scripts/setup-wordpress-settings.sh 

Executing post-install actions: 
👍 Check for global browsersync 
👍 Check for 'browser-sync.js' 
👍 Remove old 'docker-compose.browsersync.yaml' 
#ddev-generated
 
👍 Install browsersync settings for WordPress if applicable 
scripts/setup-wordpress-settings.sh: line 14: [: !=: unary operator expected
Settings file name: /Users/graham/Sites/white-label/wp-config.php
Adding wp-config-ddev-browsersync.php to: /Users/graham/Sites/white-label/wp-config.php
 
👍 Check for WordPress and disable ddev management of wp-config file 
You are reconfiguring the project at /Users/graham/Sites/white-label.
The existing configuration will be updated and replaced.
Configuring a 'wordpress' project named 'white-label' with docroot '' at '/Users/graham/Sites/white-label'.
For full details use 'ddev describe'.
Not creating CMS settings files because disable_settings_management=true
Configuration complete. You may now run 'ddev start'.
 
Overwriting existing manifest file /Users/graham/Sites/white-label/.ddev/addon-metadata/ddev-browsersync/manifest.yaml 

Installed DDEV add-on ddev/ddev-browsersync, use `ddev restart` to enable. 
Please read instructions for this add-on at the source repo at
https://github.com/ddev/ddev-browsersync
Please file issues and create pull requests there to improve it. 
Installed ddev-browsersync:2.14 from ddev/ddev-browsersync 
```

## How This PR Solves The Issue

These sort of bash scripts are not my specialism so please do check I've not done something crazy here. 

AI code advice: 
> When $DDEV_PROJECT_TYPE is empty, the expression becomes:
> `if [[ != wordpress ]] ;`
> Which triggers a syntax error (unary operator expected).

This does make me wonder why `$DDEV_PROJECT_TYPE` is causing the error as if it's empty. During testing the check passes, and doesn't hit the exit. So it's detecting as WordPress? At this 

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/graham73may/ddev-browsersync/tarball/add-and-remove-error-fix
ddev restart
```

```bash
ddev add-on remove https://github.com/graham73may/ddev-browsersync/tarball/add-and-remove-error-fix
ddev restart
```

## Release/Deployment Notes

I don't think so. 