### PR TITLE
Only include browsersync config if on a DDEV environment

### DIFF
--- a/scripts/setup-wordpress-settings.sh
+++ b/scripts/setup-wordpress-settings.sh
@@ -29,13 +29,13 @@ if grep -q "/\*\* Include for ddev-browsersync to modify WP_HOME and WP_SITEURL.
 fi
 
 echo "Adding wp-config-ddev-browsersync.php to: ${SETTINGS_FILE_NAME}"
- 
+
 # Append our code before the ddev config comment.
 awk '
 /\/\/ Include for settings managed by ddev./ {
     print "/** Include for ddev-browsersync to modify WP_HOME and WP_SITEURL. */"
     print "$ddev_browsersync_settings = dirname( __FILE__ ) . \"/wp-config-ddev-browsersync.php\";"
-    print "if ( is_readable( $ddev_browsersync_settings ) ) {"
+    print "if (  getenv( \"IS_DDEV_PROJECT\" ) == \"true\" && is_readable( $ddev_browsersync_settings ) ) {"
     print "    require_once( $ddev_browsersync_settings );"
     print "}"
     print ""


### PR DESCRIPTION
## The Issue
Had a tricky issue on a site where the ddev-config-browsersync.php file was committed and deployed by accident causing some unexpected behaviour. (I wasn't expecting the browsersync config file to be included on the server).

## How This PR Solves The Issue
The addition mirrors the condition from `wp-config-ddev.php` to stop the browsersync code loading when it's not expected to. 

```
if ( getenv( 'IS_DDEV_PROJECT' ) === 'true' ) {
```

## Manual Testing Instructions

To install:

```bash
ddev add-on get https://github.com/graham73may/ddev-browsersync/tarball/browsersync-only-for-ddev-envs
ddev restart
```

But to test, you would need to deploy both files to a non-DDEV environment. 

## Release/Deployment Notes

It would stop `ddev-config-browsersync.php` from being included on non DDEV environments (e.g. production or staging). 

It's a somewhat opinionated change but ddev browsersync should only be used during development (right?)