### PR TITLE
fix: quote $DDEV_SITE_PATH to handle paths with spaces, fixes #85

### DIFF
--- a/scripts/remove-wordpress-settings.sh
+++ b/scripts/remove-wordpress-settings.sh
@@ -26,5 +26,5 @@ awk '
 /\/\*\* Include for ddev-browsersync to modify WP_HOME and WP_SITEURL\./ { skip=1 }
 skip && /\}.*$/ { skip=0; getline; next }
 !skip
-' ${DDEV_SITE_PATH}/wp-config.php > ${DDEV_SITE_PATH}/wp-config-temp.php
-mv ${DDEV_SITE_PATH}/wp-config-temp.php ${DDEV_SITE_PATH}/wp-config.php
+' "${DDEV_SITE_PATH}/wp-config.php" > "${DDEV_SITE_PATH}/wp-config-temp.php"
+mv "${DDEV_SITE_PATH}/wp-config-temp.php" "${DDEV_SITE_PATH}/wp-config.php"

--- a/scripts/setup-wordpress-settings.sh
+++ b/scripts/setup-wordpress-settings.sh
@@ -17,14 +17,14 @@ else
   DDEV_SITE_PATH=$DDEV_APPROOT
 fi
 
-cp scripts/wp-config-ddev-browsersync.php $DDEV_SITE_PATH/
+cp scripts/wp-config-ddev-browsersync.php "$DDEV_SITE_PATH/"
 
 SETTINGS_FILE_NAME="${DDEV_SITE_PATH}/wp-config.php"
 
 echo "Settings file name: ${SETTINGS_FILE_NAME}"
 
 # If wp-config.php already contains the require_once() then exit early.
-if grep -q "/\*\* Include for ddev-browsersync to modify WP_HOME and WP_SITEURL. \*/" ${DDEV_SITE_PATH}/wp-config.php; then
+if grep -q "/\*\* Include for ddev-browsersync to modify WP_HOME and WP_SITEURL. \*/" "${DDEV_SITE_PATH}/wp-config.php"; then
    exit 0
 fi
 
@@ -43,7 +43,7 @@ awk '
     next
 }
 {print}
-' ${DDEV_SITE_PATH}/wp-config.php > ${DDEV_SITE_PATH}/wp-config-temp.php
+' "${DDEV_SITE_PATH}/wp-config.php" > "${DDEV_SITE_PATH}/wp-config-temp.php"
 
 # Replace the real config file with the modified version in temporary file.
-mv ${DDEV_SITE_PATH}/wp-config-temp.php ${DDEV_SITE_PATH}/wp-config.php
+mv "${DDEV_SITE_PATH}/wp-config-temp.php" "${DDEV_SITE_PATH}/wp-config.php"


### PR DESCRIPTION
Unquoted variable caused commands in scripts to fail when the site path contained spaces. Quoting ensures the path is treated as a single argument.

closes https://github.com/ddev/ddev-browsersync/issues/85

## The Issue

- https://github.com/ddev/ddev-browsersync/issues/85